### PR TITLE
Fix MySQL issue with updateBatch()

### DIFF
--- a/src/main/java/com/strider/datadefender/DatabaseAnonymizer.java
+++ b/src/main/java/com/strider/datadefender/DatabaseAnonymizer.java
@@ -190,8 +190,12 @@ public class DatabaseAnonymizer implements IAnonymizer {
                 query.append(")");
             }
         }
-        
-        final PreparedStatement stmt = dbFactory.getConnection().prepareStatement(query.toString());
+
+        final PreparedStatement stmt = dbFactory.getConnection().prepareStatement(
+                query.toString(),
+                ResultSet.TYPE_FORWARD_ONLY,
+                ResultSet.CONCUR_UPDATABLE
+        );
         if (dbFactory.getVendorName().equalsIgnoreCase("mysql")) {
             stmt.setFetchSize(Integer.MIN_VALUE);
         }


### PR DESCRIPTION
Mr. Armenak,

I ran into an issue on MySQL.  updateBatch was trying to lock the table, and if the number of records exceeds the number of records to update in a single updateBatch, a concurrency issue was occurring.

Not sure why this is only happening for me now, but opening the 'SELECT' statement with a ResultSet.CONCUR_UPDATABLE gets it working again.

Some supported databases may not support CONCUR_UPDATABLE, so I'm submitting as a pull request until someone gets a chance to check that out.

Thanks,
Zaahid