### PR TITLE
Upgrade MariaDB Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -358,7 +358,7 @@
         <dependency>
           <groupId>org.mariadb.jdbc</groupId>
           <artifactId>mariadb-java-client</artifactId>
-          <version>2.6.0</version>
+          <version>3.1.2</version>
         </dependency>
       </dependencies>
     </profile>


### PR DESCRIPTION
Fix bad column size for LONGTEXT / TEXT

Fixed in MariaDB Connector 2.7.1  (https://jira.mariadb.org/browse/CONJ-841), upgrade to 3.2.0 (Java 8/11/17 compatibility)